### PR TITLE
README/golint/examples: Standarize README, make golint happy, fix examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.6
+  - 1.8
   - tip
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-test: deps
-	go test ./muxtest
+test: gx-bins
+	cd muxtest && gx install --global && gx-go rewrite && go test -v
 
 test_race: deps
-	go test -race ./muxtest
+	cd muxtest && gx install --global && gx-go rewrite && go test -race -v
 
 gx-bins:
 	go get github.com/whyrusleeping/gx
@@ -14,3 +14,4 @@ deps: gx-bins
 
 clean: gx-bins
 	gx-go rewrite --undo
+	cd muxtest && gx-go rewrite --undo

--- a/conn.go
+++ b/conn.go
@@ -63,7 +63,7 @@ func newConn(nconn tpt.Conn, tconn smux.Conn, s *Swarm) *Conn {
 	}
 }
 
-// String returns a string representation of the Conn
+// String returns a string representation of the Conn.
 func (c *Conn) String() string {
 	c.streamLock.RLock()
 	ls := len(c.streams)
@@ -72,12 +72,12 @@ func (c *Conn) String() string {
 	return fmt.Sprintf(f, ls, c.netConn.LocalAddr(), c.netConn.RemoteAddr())
 }
 
-// Swarm returns the Swarm associated with this Conn
+// Swarm returns the Swarm associated with this Conn.
 func (c *Conn) Swarm() *Swarm {
 	return c.swarm
 }
 
-// NetConn returns the underlying net.Conn
+// NetConn returns the underlying net.Conn.
 func (c *Conn) NetConn() net.Conn {
 	return c.netConn
 }
@@ -88,26 +88,27 @@ func (c *Conn) Conn() smux.Conn {
 	return c.smuxConn
 }
 
-// Groups returns the Groups this Conn belongs to
+// Groups returns the Groups this Conn belongs to.
 func (c *Conn) Groups() []Group {
 	return c.groups.Groups()
 }
 
-// InGroup returns whether this Conn belongs to a Group
+// InGroup returns whether this Conn belongs to a Group.
 func (c *Conn) InGroup(g Group) bool {
 	return c.groups.Has(g)
 }
 
-// AddGroup assigns given Group to Conn
+// AddGroup assigns given Group to Conn.
 func (c *Conn) AddGroup(g Group) {
 	c.groups.Add(g)
 }
 
-// Stream returns a stream associated with this Conn
+// NewStream returns a stream associated with this Conn.
 func (c *Conn) NewStream() (*Stream, error) {
 	return c.swarm.NewStreamWithConn(c)
 }
 
+// Streams returns the slice of all streams associated to this Conn.
 func (c *Conn) Streams() []*Stream {
 	c.streamLock.RLock()
 	defer c.streamLock.RUnlock()
@@ -177,6 +178,8 @@ func ConnsWithGroup(g Group, conns []*Conn) []*Conn {
 	return out
 }
 
+// ConnInConns returns true if a connection belongs to the
+// conns slice.
 func ConnInConns(c1 *Conn, conns []*Conn) bool {
 	for _, c2 := range conns {
 		if c2 == c1 {

--- a/doc.go
+++ b/doc.go
@@ -1,12 +1,11 @@
 // Package peerstream is a peer-to-peer networking library that multiplexes
-// connections to many hosts. It tried to simplify the complexity of:
+// connections to many hosts. It attempts to simplify the complexity of:
 //
-//   * accepting incoming connections over **multiple** listeners
-//   * dialing outgoing connections over **multiple** transports
-//   * multiplexing **multiple** connections per-peer
-//   * multiplexing **multiple** different servers or protocols
-//   * handling backpressure correctly
-//   * handling stream multiplexing (we use SPDY, but maybe QUIC some day)
-//   * providing a **simple** interface to the user
-//
+// * accepting incoming connections over **multiple** listeners
+// * dialing outgoing connections over **multiple** transports
+// * multiplexing **multiple** connections per-peer
+// * multiplexing **multiple** different servers or protocols
+// * handling backpressure correctly
+// * handling stream multiplexing
+// * providing a **simple** interface to the user
 package peerstream

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,0 +1,23 @@
+all: examples
+
+examples: deps example blockhandler/blockhandler
+
+blockhandler/blockhandler:
+	cd blockhandler && go build blockhandler.go
+example:
+	go build example.go
+
+gx-bins:
+	go get github.com/whyrusleeping/gx
+	go get github.com/whyrusleeping/gx-go
+
+deps: gx-bins
+	gx --verbose install --global
+	gx-go rewrite
+
+clean: gx-bins
+	gx-go rewrite --undo
+	rm example
+	rm blockhandler/blockhandler
+
+.PHONY = clean deps gx-bins examples all

--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,42 @@
+{
+  "author": "hector",
+  "bugs": {
+    "url": "https://github.com/libp2p/go-peerstream"
+  },
+  "gx": {
+    "dvcsimport": "github.com/libp2p/go-peerstream/example"
+  },
+  "gxDependencies": [
+    {
+      "author": "multiformats",
+      "hash": "QmREaA5NwG2wmQJNrFPbPLtnWh7WysRcexobhTZDSxUEtE",
+      "name": "go-multiaddr",
+      "version": "1.2.1"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmTPm4fmjZtMngaxaGVa8wq9ZzJ2oAsT1DNgCCXJboZPi5",
+      "name": "go-tcp-transport",
+      "version": "1.1.7"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "Qmbn7RYyWzBVXiUp9jZ1dA4VADHy9DtS7iZLwfhEUQvm3U",
+      "name": "go-smux-yamux",
+      "version": "1.2.0"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmXGtG3B4ALpLm4WcaG7KRHSsUCsjKJ5vKyNcQRoJAPq1P",
+      "name": "go-peerstream",
+      "version": "1.6.0"
+    }
+  ],
+  "gxVersion": "0.10.0",
+  "language": "go",
+  "license": "MIT",
+  "name": "example",
+  "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
+  "version": "0.0.0"
+}
+

--- a/handlers.go
+++ b/handlers.go
@@ -5,6 +5,10 @@ import (
 	"math/rand"
 )
 
+// SelectRandomConn defines a function which takes
+// a slice of Conns and returns a randomly selected one.
+// Note that it is user's responsability to rand.Seed before
+// using.
 var SelectRandomConn = func(conns []*Conn) *Conn {
 	if len(conns) == 0 {
 		return nil
@@ -13,6 +17,9 @@ var SelectRandomConn = func(conns []*Conn) *Conn {
 	return conns[rand.Intn(len(conns))]
 }
 
+// EchoHandler launches a StreamHandling go-routine
+// which echoes everything read from the stream
+// back into it. It closes the stream at the end.
 func EchoHandler(s *Stream) {
 	go func() {
 		io.Copy(s, s)
@@ -20,10 +27,14 @@ func EchoHandler(s *Stream) {
 	}()
 }
 
+// CloseHandler is a StreamHandler which simply closes
+// the stream.
 func CloseHandler(s *Stream) {
 	s.Close()
 }
 
+// NoOpStreamHandler is a StreamHandler which does nothing.
 func NoOpStreamHandler(s *Stream) {}
 
+// NoOpConnHandler is a connection handler which does nothing.
 func NoOpConnHandler(c *Conn) {}

--- a/listener.go
+++ b/listener.go
@@ -16,6 +16,9 @@ import (
 // node to consume all its resources accepting new connections.
 var AcceptConcurrency = 200
 
+// Listener wraps a libp2p-transport Listener and a Swarm and a
+// group set. Listener is returned by Swarm.AddListener() and provides
+// its purpose is to be able to associate Swarm/Listener pairs to groups.
 type Listener struct {
 	netList tpt.Listener
 	groups  groupSet
@@ -32,6 +35,8 @@ func newListener(nl tpt.Listener, s *Swarm) *Listener {
 	}
 }
 
+// NetListener returns the libp2p-transport Listener wrapped
+// in Listener.
 func (l *Listener) NetListener() tpt.Listener {
 	return l.netList
 }
@@ -117,7 +122,8 @@ func (l *Listener) accept() {
 	}
 }
 
-// AcceptError returns the error that we **might** on listener close
+// AcceptErrors returns a channel for the errors
+// that we **might** get on listener close.
 func (l *Listener) AcceptErrors() <-chan error {
 	return l.acceptErr
 }
@@ -135,6 +141,7 @@ func (l *Listener) teardown() {
 	l.swarm.listenerLock.Unlock()
 }
 
+// Close closes the underlying libp2p-transport Listener.
 func (l *Listener) Close() error {
 	return l.netList.Close()
 }

--- a/muxtest/package.json
+++ b/muxtest/package.json
@@ -27,9 +27,15 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmNiFRHdeJgN9svSGkEtmhd5sGvv3suSKZ1sRkLqoCzL76",
+      "hash": "QmXGtG3B4ALpLm4WcaG7KRHSsUCsjKJ5vKyNcQRoJAPq1P",
+      "name": "go-peerstream",
+      "version": "1.6.0"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmTPm4fmjZtMngaxaGVa8wq9ZzJ2oAsT1DNgCCXJboZPi5",
       "name": "go-tcp-transport",
-      "version": "1.1.0"
+      "version": "1.1.7"
     }
   ],
   "gxVersion": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "whyrusleeping",
   "bugs": {
-    "url": "https://github.com/jbenet/go-peerstream"
+    "url": "https://github.com/libp2p/go-peerstream"
   },
   "gx": {
     "dvcsimport": "github.com/libp2p/go-peerstream"
@@ -40,7 +40,7 @@
   ],
   "gxVersion": "0.7.0",
   "language": "go",
-  "license": "",
+  "license": "MIT",
   "name": "go-peerstream",
   "releaseCmd": "git commit -a -m \"gx release $VERSION\"",
   "version": "1.6.0"

--- a/stream.go
+++ b/stream.go
@@ -42,7 +42,7 @@ func (s *Stream) String() string {
 	return fmt.Sprintf(f, s.conn.NetConn().LocalAddr(), s.conn.NetConn().RemoteAddr())
 }
 
-// SPDYStream returns the underlying *spdystream.Stream
+// Stream returns the underlying stream muxer Stream
 func (s *Stream) Stream() smux.Stream {
 	return s.smuxStream
 }
@@ -72,34 +72,56 @@ func (s *Stream) AddGroup(g Group) {
 	s.groups.Add(g)
 }
 
+// Read reads from the stream and returns the number
+// of bytes read. It implements the io.Reader interface.
 func (s *Stream) Read(p []byte) (n int, err error) {
 	return s.smuxStream.Read(p)
 }
 
+// Write writes to the stream and returns the number
+// of bytes written. It implements the io.Writer interface.
 func (s *Stream) Write(p []byte) (n int, err error) {
 	return s.smuxStream.Write(p)
 }
 
+// Close closes the stream and removes it from the swarm.
 func (s *Stream) Close() error {
 	return s.conn.swarm.removeStream(s)
 }
 
+// Protocol returns the protocol identifier associated to this Stream.
 func (s *Stream) Protocol() protocol.ID {
 	return s.protocol
 }
 
+// SetProtocol sets the protocol identifier for this Stream.
 func (s *Stream) SetProtocol(p protocol.ID) {
 	s.protocol = p
 }
 
+// SetDeadline sets the read and write deadlines associated
+// with the Stream. It is equivalent to calling both
+// SetReadDeadline and SetWriteDeadline.
+//
+// A deadline is an absolute time after which I/O operations
+// fail with a timeout (see type Error) instead of
+// blocking.
 func (s *Stream) SetDeadline(t time.Time) error {
 	return s.smuxStream.SetDeadline(t)
 }
 
+// SetReadDeadline sets the deadline for future Read calls
+// and any currently-blocked Read call.
+// A zero value for t means Read will not time out.
 func (s *Stream) SetReadDeadline(t time.Time) error {
 	return s.smuxStream.SetReadDeadline(t)
 }
 
+// SetWriteDeadline sets the deadline for future Write calls
+// and any currently-blocked Write call.
+// Even if write times out, it may return n > 0, indicating that
+// some of the data was successfully written.
+// A zero value for t means Write will not time out.
 func (s *Stream) SetWriteDeadline(t time.Time) error {
 	return s.smuxStream.SetWriteDeadline(t)
 }


### PR DESCRIPTION
This converts this into an standarized readme, adds correct badges, gx
instructions etc.

It sets me @hsanjuan as "maintainer", because there is no maintainer previously defined
so why not.

I have made golint happy too.

License: MIT
Signed-off-by: Hector Sanjuan <code@hector.link>