### PR TITLE
remove connection setup

### DIFF
--- a/muxtest/mux_test.go
+++ b/muxtest/mux_test.go
@@ -3,17 +3,37 @@ package muxtest
 import (
 	"testing"
 
+	tpt "github.com/libp2p/go-libp2p-transport"
+	tcpc "github.com/libp2p/go-tcp-transport"
+	quict "github.com/marten-seemann/libp2p-quic-transport"
+	ma "github.com/multiformats/go-multiaddr"
 	multistream "github.com/whyrusleeping/go-smux-multistream"
 	spdy "github.com/whyrusleeping/go-smux-spdystream"
 	yamux "github.com/whyrusleeping/go-smux-yamux"
 )
 
 func TestYamuxTransport(t *testing.T) {
-	SubtestAll(t, yamux.DefaultTransport)
+	l := listenerOpts{
+		transportCb: func() tpt.Transport { return tcpc.NewTCPTransport() },
+		localaddr:   ma.StringCast("/ip4/127.0.0.1/tcp/0"),
+	}
+	SubtestAll(t, l, yamux.DefaultTransport)
 }
 
 func TestSpdyStreamTransport(t *testing.T) {
-	SubtestAll(t, spdy.Transport)
+	l := listenerOpts{
+		transportCb: func() tpt.Transport { return tcpc.NewTCPTransport() },
+		localaddr:   ma.StringCast("/ip4/127.0.0.1/tcp/0"),
+	}
+	SubtestAll(t, l, spdy.Transport)
+}
+
+func TestQuicTransport(t *testing.T) {
+	l := listenerOpts{
+		transportCb: func() tpt.Transport { return quict.NewQuicTransport() },
+		localaddr:   ma.StringCast("/ip4/127.0.0.1/udp/0/quic"),
+	}
+	SubtestAll(t, l, nil)
 }
 
 /*
@@ -27,8 +47,12 @@ func TestMuxadoTransport(t *testing.T) {
 */
 
 func TestMultistreamTransport(t *testing.T) {
+	l := listenerOpts{
+		transportCb: func() tpt.Transport { return tcpc.NewTCPTransport() },
+		localaddr:   ma.StringCast("/ip4/127.0.0.1/tcp/0"),
+	}
 	tpt := multistream.NewBlankTransport()
 	tpt.AddTransport("/yamux", yamux.DefaultTransport)
 	tpt.AddTransport("/spdy", spdy.Transport)
-	SubtestAll(t, tpt)
+	SubtestAll(t, l, tpt)
 }

--- a/stream.go
+++ b/stream.go
@@ -41,7 +41,7 @@ func newStream(ss smux.Stream, c *Conn) *Stream {
 // String returns a string representation of the Stream
 func (s *Stream) String() string {
 	f := "<peerstream.Stream %s <--> %s>"
-	return fmt.Sprintf(f, s.conn.NetConn().LocalAddr(), s.conn.NetConn().RemoteAddr())
+	return fmt.Sprintf(f, s.conn.Conn().LocalAddr(), s.conn.Conn().RemoteAddr())
 }
 
 // Stream returns the underlying smux.Stream

--- a/stream.go
+++ b/stream.go
@@ -17,7 +17,7 @@ import (
 type StreamHandler func(s *Stream)
 
 // Stream is an io.{Read,Write,Close}r to a remote counterpart.
-// It wraps a spdystream.Stream, and links it to a Conn and groups
+// It wraps a smux.Stream, and links it to a Conn and groups
 type Stream struct {
 	smuxStream smux.Stream
 
@@ -44,7 +44,7 @@ func (s *Stream) String() string {
 	return fmt.Sprintf(f, s.conn.NetConn().LocalAddr(), s.conn.NetConn().RemoteAddr())
 }
 
-// Stream returns the underlying stream muxer Stream
+// Stream returns the underlying smux.Stream
 func (s *Stream) Stream() smux.Stream {
 	return s.smuxStream
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -10,7 +10,7 @@ import (
 
 type fakeSmuxStream struct {
 	smux.Stream
-	conn      *fakeSmuxConn
+	conn      *fakeconn
 	closeLock sync.Mutex
 	closed    chan struct{}
 }

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -50,7 +50,7 @@ func (mn *myNotifee) OpenedStream(*Stream) {}
 func (mn *myNotifee) ClosedStream(*Stream) {}
 
 func TestNotificationOrdering(t *testing.T) {
-	s := NewSwarm(nil)
+	s := NewSwarm()
 	notifiee := &myNotifee{conns: make(map[*Conn]bool)}
 
 	s.Notify(notifiee)


### PR DESCRIPTION
This PR moves the connection setup to go-libp2p-conn, see https://github.com/libp2p/go-libp2p-conn/pull/9.

It should be merged once we activate multi-stream support, as added in https://github.com/libp2p/go-libp2p-transport/pull/20.