### PR TITLE
complete notifications before returning from notifyAll

### DIFF
--- a/swarm.go
+++ b/swarm.go
@@ -409,7 +409,10 @@ func (s *Swarm) notifyAll(notification func(n Notifiee)) {
 }
 
 // Notifiee is an interface for an object wishing to receive
-// notifications from a Swarm
+// notifications from a Swarm. Notifiees should take care not to register other
+// notifiees inside of a notification.  They should also take care to do as
+// little work as possible within their notification, putting any blocking work
+// out into a goroutine.
 type Notifiee interface {
 	Connected(*Conn)      // called when a connection opened
 	Disconnected(*Conn)   // called when a connection closed

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -1,0 +1,77 @@
+package peerstream
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	tpt "github.com/libp2p/go-libp2p-transport"
+)
+
+type fakeconn struct {
+	tpt.Conn
+}
+
+func (f *fakeconn) Close() error {
+	return nil
+}
+
+type myNotifee struct {
+	conns  map[*Conn]bool
+	failed bool
+}
+
+func (mn *myNotifee) Connected(c *Conn) {
+	_, ok := mn.conns[c]
+	if ok {
+		fmt.Println("got connected notif for already connected peer")
+		mn.failed = true
+		return
+	}
+
+	mn.conns[c] = true
+	time.Sleep(time.Millisecond * 5)
+}
+
+func (mn *myNotifee) Disconnected(c *Conn) {
+	_, ok := mn.conns[c]
+	if !ok {
+		fmt.Println("got disconnected notif for unknown peer")
+		mn.failed = true
+		return
+	}
+
+	delete(mn.conns, c)
+}
+
+func (mn *myNotifee) OpenedStream(*Stream) {}
+func (mn *myNotifee) ClosedStream(*Stream) {}
+
+func TestNotificationOrdering(t *testing.T) {
+	s := NewSwarm(nil)
+	notifiee := &myNotifee{conns: make(map[*Conn]bool)}
+
+	s.Notify(notifiee)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				nc := new(fakeconn)
+				c, err := s.AddConn(nc)
+				if err != nil {
+					t.Error(err)
+				}
+				c.Close()
+			}
+		}()
+	}
+
+	wg.Wait()
+	if notifiee.failed {
+		t.Fatal("we've got problems")
+	}
+}


### PR DESCRIPTION
I'm pretty sure this is the cause of the occasional bitswap hanging bug.

the scenario that could cause it is a connection coming in and being closed quickly. The disconnect notification could be handled by bitswap *before* the connected notification, and then be thrown away leading to bitswap thinking it has a valid open connection to a peer when it really doesnt. Then, when another connection opens up, bitswap doesnt care, and continues attempting to use the old connections reference.

I still need to verify this, but in any case, this patch should be good. 