### PR TITLE
don't use conn.Serve, implement the AcceptStream loop here

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.7.0: QmVNPgPmEG4QKaDKkxMPKY34Z53n8efzv1sEh4NTsdhto7
+2.0.0: Qma1raveZpdRgcGkhzi1euLqmBgiVPNhHei1Ye39o7Joug

--- a/conn.go
+++ b/conn.go
@@ -147,10 +147,10 @@ func (c *Conn) Close() error {
 
 	c.closed = true
 
-	// close streams
+	// reset streams
 	streams := c.Streams()
 	for _, s := range streams {
-		s.Close()
+		s.Reset()
 	}
 
 	// close underlying connection
@@ -302,6 +302,11 @@ func (s *Swarm) setupStream(smuxStream smux.Stream, c *Conn) *Stream {
 	return stream
 }
 
+// TODO: Really, we need to either not track them here or, possibly, add a
+// notification system to go-stream-muxer (shudder).
+// Alternatively, we could garbage collect them like we do connections but then
+// we'd need a way to determine which connections are open (we'd need IsClosed)
+// methods.
 func (s *Swarm) removeStream(stream *Stream) error {
 
 	// remove from our maps
@@ -312,7 +317,9 @@ func (s *Swarm) removeStream(stream *Stream) error {
 	s.streamLock.Unlock()
 	stream.conn.streamLock.Unlock()
 
-	err := stream.smuxStream.Close()
+	err := stream.smuxStream.Reset()
+	// TODO: Does this even make sense with half-open streams?
+	// TODO: This will fire once per call to Reset (possibly multiple times...)
 	s.notifyAll(func(n Notifiee) {
 		n.ClosedStream(stream)
 	})

--- a/conn.go
+++ b/conn.go
@@ -6,8 +6,8 @@ import (
 	"net"
 	"sync"
 
-	smux "github.com/jbenet/go-stream-muxer"
 	tpt "github.com/libp2p/go-libp2p-transport"
+	smux "github.com/libp2p/go-stream-muxer"
 )
 
 // ConnHandler is a function which receives a Conn. It allows

--- a/handlers.go
+++ b/handlers.go
@@ -27,10 +27,10 @@ func EchoHandler(s *Stream) {
 	}()
 }
 
-// CloseHandler is a StreamHandler which simply closes
+// ResetHandler is a StreamHandler which simply resets
 // the stream.
-func CloseHandler(s *Stream) {
-	s.Close()
+func ResetHandler(s *Stream) {
+	s.Reset()
 }
 
 // NoOpStreamHandler is a StreamHandler which does nothing.

--- a/muxtest/muxt.go
+++ b/muxtest/muxt.go
@@ -14,7 +14,7 @@ import (
 
 	ps "github.com/libp2p/go-peerstream"
 
-	smux "github.com/jbenet/go-stream-muxer"
+	smux "github.com/libp2p/go-stream-muxer"
 	tcpc "github.com/libp2p/go-tcp-transport"
 	ma "github.com/multiformats/go-multiaddr"
 )

--- a/muxtest/muxt.go
+++ b/muxtest/muxt.go
@@ -14,7 +14,7 @@ import (
 
 	ps "github.com/libp2p/go-peerstream"
 
-	smux "github.com/libp2p/go-stream-muxer"
+	smux "github.com/jbenet/go-stream-muxer"
 	tcpc "github.com/libp2p/go-tcp-transport"
 	ma "github.com/multiformats/go-multiaddr"
 )

--- a/muxtest/package.json
+++ b/muxtest/package.json
@@ -36,6 +36,12 @@
       "hash": "QmTPm4fmjZtMngaxaGVa8wq9ZzJ2oAsT1DNgCCXJboZPi5",
       "name": "go-tcp-transport",
       "version": "1.1.7"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmeZBgYBHvxMukGK5ojg28BCNLB9SeXqT7XXg6o7r2GbJy",
+      "name": "go-stream-muxer",
+      "version": "1.1.0"
     }
   ],
   "gxVersion": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
   "license": "MIT",
   "name": "go-peerstream",
   "releaseCmd": "git commit -a -m \"gx release $VERSION\"",
-  "version": "1.7.0"
+  "version": "2.0.0"
 }
 

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmYsbrKfXboT5A5Zvh9YW7oPMpV4kNKFkx9bmanZRKj19y",
+      "hash": "QmY9JXR3FupnYAYJWK9aMr9bCpqWKcToQ1tz8DVGTrHpHw",
       "name": "go-stream-muxer",
-      "version": "2.0.0"
+      "version": "3.0.0"
     },
     {
       "author": "whyrusleeping",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmeZBgYBHvxMukGK5ojg28BCNLB9SeXqT7XXg6o7r2GbJy",
+      "hash": "QmYsbrKfXboT5A5Zvh9YW7oPMpV4kNKFkx9bmanZRKj19y",
       "name": "go-stream-muxer",
-      "version": "1.1.0"
+      "version": "2.0.0"
     },
     {
       "author": "whyrusleeping",

--- a/stream.go
+++ b/stream.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	smux "github.com/jbenet/go-stream-muxer"
 	protocol "github.com/libp2p/go-libp2p-protocol"
+	smux "github.com/libp2p/go-stream-muxer"
 )
 
 // StreamHandler is a function which receives a Stream. It

--- a/stream.go
+++ b/stream.go
@@ -86,14 +86,14 @@ func (s *Stream) Write(p []byte) (n int, err error) {
 	return s.smuxStream.Write(p)
 }
 
-// Reset resets the stream.
+// Reset resets the stream and removes it from the swarm.
 func (s *Stream) Reset() error {
-	return s.smuxStream.Reset()
+	return s.conn.swarm.removeStream(s)
 }
 
-// Close closes the stream and removes it from the swarm.
+// Close closes the write end of the stream.
 func (s *Stream) Close() error {
-	return s.conn.swarm.removeStream(s)
+	return s.smuxStream.Close()
 }
 
 // Protocol returns the protocol identifier associated to this Stream.

--- a/stream.go
+++ b/stream.go
@@ -26,6 +26,8 @@ type Stream struct {
 	protocol protocol.ID
 }
 
+var _ smux.Stream = &Stream{}
+
 func newStream(ss smux.Stream, c *Conn) *Stream {
 	s := &Stream{
 		conn:       c,
@@ -82,6 +84,11 @@ func (s *Stream) Read(p []byte) (n int, err error) {
 // of bytes written. It implements the io.Writer interface.
 func (s *Stream) Write(p []byte) (n int, err error) {
 	return s.smuxStream.Write(p)
+}
+
+// Reset resets the stream.
+func (s *Stream) Reset() error {
+	return s.smuxStream.Reset()
 }
 
 // Close closes the stream and removes it from the swarm.

--- a/swarm.go
+++ b/swarm.go
@@ -335,7 +335,7 @@ func (s *Swarm) Close() error {
 
 	// automatically close everything new we get.
 	s.SetConnHandler(func(c *Conn) { c.Close() })
-	s.SetStreamHandler(func(s *Stream) { s.Close() })
+	s.SetStreamHandler(func(s *Stream) { s.Reset() })
 
 	var wgl sync.WaitGroup
 	for _, l := range s.Listeners() {

--- a/swarm.go
+++ b/swarm.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	smux "github.com/jbenet/go-stream-muxer"
 	tpt "github.com/libp2p/go-libp2p-transport"
+	smux "github.com/libp2p/go-stream-muxer"
 )
 
 // fd is a (file) descriptor, unix style


### PR DESCRIPTION
We should merge this when merging https://github.com/libp2p/go-peerstream/pull/6.

Depends on #4. Please merge that one first.