### PR TITLE
reduce CPU usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,24 @@
-language: go
+sudo: false
 
+
+language: go
 go:
   - 1.8
-  - tip
-
+  
+install:
+  - go get github.com/whyrusleeping/gx
+  - go get github.com/whyrusleeping/gx-go
+  - gx install --global
 script:
-  - make test
-  # - go test -race -cpu=5 ./...
+  - gx test -v -race -coverprofile=coverage.txt -covermode=atomic .
+  
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
+cache:
+  directories:
+    - $GOPATH/src/gx
+
+notifications:
+  email: false
+  

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  range: "50...100"
+comment: off

--- a/conn.go
+++ b/conn.go
@@ -371,7 +371,7 @@ func (s *Swarm) removeConn(conn *Conn) {
 	defer s.connLock.Unlock()
 	delete(s.conns, conn)
 	delete(s.connByNet, conn.netConn)
-	for g := range conn.groups.Groups() {
+	for _, g := range conn.groups.Groups() {
 		s.removeConnGroup(conn, g)
 	}
 }

--- a/conn.go
+++ b/conn.go
@@ -236,14 +236,14 @@ func (s *Swarm) setupConn(netConn tpt.Conn, isServer bool) (*Conn, error) {
 
 	// first, check if we already have it, to avoid constructing it
 	// if it is already there
-	s.connLock.Lock()
+	s.connLock.RLock()
 	for c := range s.conns {
 		if c.netConn == netConn {
-			s.connLock.Unlock()
+			s.connLock.RUnlock()
 			return c, nil
 		}
 	}
-	s.connLock.Unlock()
+	s.connLock.RUnlock()
 	// construct the connection without hanging onto the lock
 	// (as there could be deadlock if so.)
 

--- a/conn.go
+++ b/conn.go
@@ -272,7 +272,7 @@ func (s *Swarm) setupConn(netConn tpt.Conn, isServer bool, initialGroups []Group
 	s.conns[c] = struct{}{}
 	s.connByNet[netConn] = c
 	for _, g := range initialGroups {
-		c.groups.m[s] = struct{}{}
+		c.groups.m[g] = struct{}{}
 		s.addConnGroup(c, g)
 	}
 	return c, nil

--- a/conn.go
+++ b/conn.go
@@ -264,7 +264,6 @@ func (s *Swarm) setupConn(netConn tpt.Conn, isServer bool, initialGroups []Group
 
 	// check for it again as it may have been added already. (TOCTTOU)
 	if c, ok := s.connByNet[netConn]; ok {
-		s.connLock.RUnlock()
 		return c, nil
 	}
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -116,6 +116,10 @@ func TestConnsWithGroup(t *testing.T) {
 		t.Fatalf("expected group '%v', got group '%v'", g, groups[0])
 	}
 
+	b.closingLock.Lock()
+	defer b.closingLock.Unlock()
+	c.closingLock.Lock()
+	defer c.closingLock.Unlock()
 	if !b.closing {
 		t.Fatal("b should at least be closing")
 	}

--- a/conn_test.go
+++ b/conn_test.go
@@ -155,8 +155,13 @@ func TestAddConnTwice(t *testing.T) {
 	ca := <-conns
 	cb := <-conns
 
-	if ca != cb {
-		t.Fatalf("initialized a single net conn twice: %v != %v", ca, cb)
+	cc, err := s.AddConn(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if ca != cb || ca != cc {
+		t.Fatalf("initialized a single net conn twice: %v != %v != %v", ca, cb, cc)
 	}
 	ca.Close()
 	if len(s.connByNet) != 0 || len(s.conns) != 0 {

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,0 +1,198 @@
+package peerstream
+
+import (
+	"net"
+	"sync"
+	"testing"
+
+	tpt "github.com/libp2p/go-libp2p-transport"
+	smux "github.com/libp2p/go-stream-muxer"
+)
+
+type fakeconn struct {
+	tpt.Conn
+}
+
+func (f *fakeconn) Close() error {
+	return nil
+}
+
+var _ net.Conn = new(fakeconn)
+
+type fakeSmuxConn struct {
+	smux.Conn
+	closed bool
+}
+
+func (fsc *fakeSmuxConn) IsClosed() bool {
+	return fsc.closed
+}
+
+func (fsc *fakeSmuxConn) Close() error {
+	return nil
+}
+
+var _ smux.Conn = new(fakeSmuxConn)
+
+func TestConnsWithGroup(t *testing.T) {
+	s := NewSwarm(nil)
+	a := newConn(nil, &fakeSmuxConn{}, s)
+	b := newConn(nil, &fakeSmuxConn{closed: true}, s)
+	c := newConn(nil, &fakeSmuxConn{closed: true}, s)
+	g := "foo"
+
+	s.conns[a] = struct{}{}
+	s.conns[b] = struct{}{}
+	s.conns[c] = struct{}{}
+
+	a.AddGroup(g)
+	b.AddGroup(g)
+	c.AddGroup(g)
+
+	conns := s.ConnsWithGroup(g)
+	if len(conns) != 1 {
+		t.Fatal("should have only gotten one")
+	}
+
+	if !b.closing {
+		t.Fatal("b should at least be closing")
+	}
+
+	if !c.closing {
+		t.Fatal("c should at least be closing")
+	}
+}
+
+func TestAddConnTwice(t *testing.T) {
+	ready := new(sync.WaitGroup)
+	pause := make(chan struct{})
+	conns := make(chan *Conn)
+	s := NewSwarm(fakeTransport{func(c net.Conn, isServer bool) (smux.Conn, error) {
+		ready.Done()
+		<-pause
+		return nil, nil
+	}})
+	c := new(fakeconn)
+	for i := 0; i < 2; i++ {
+		ready.Add(1)
+		go func() {
+			pc, err := s.AddConn(c)
+			if err != nil {
+				t.Error(err)
+			}
+			conns <- pc
+		}()
+	}
+	ready.Wait()
+	close(pause)
+
+	ca := <-conns
+	cb := <-conns
+
+	if ca != cb {
+		t.Fatalf("initialized a single net conn twice: %v != %v", ca, cb)
+	}
+	ca.Close()
+	if len(s.connByNet) != 0 || len(s.conns) != 0 {
+		t.Fatal("leaked connections")
+	}
+}
+
+func TestConnIdx(t *testing.T) {
+	s := NewSwarm(nil)
+	c, err := s.AddConn(new(fakeconn))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := "foo"
+	g2 := "bar"
+
+	if len(s.ConnsWithGroup(g)) != 0 {
+		t.Fatal("should have gotten none")
+	}
+
+	c.AddGroup(g)
+	if !c.InGroup(g) {
+		t.Fatal("should be in the appropriate group")
+	}
+	if len(s.ConnsWithGroup(g)) != 1 {
+		t.Fatal("should have only gotten one")
+	}
+
+	c.Close()
+	if !c.InGroup(g) {
+		t.Fatal("should still be in the appropriate group")
+	}
+	if len(s.ConnsWithGroup(g)) != 0 {
+		t.Fatal("should have gotten none")
+	}
+
+	c.AddGroup(g2)
+	if !c.InGroup(g2) {
+		t.Fatal("should now be in group 2")
+	}
+	if c.InGroup("bla") {
+		t.Fatal("should not be in arbitrary groups")
+	}
+	if len(s.ConnsWithGroup(g)) != 0 {
+		t.Fatal("should still have gotten none")
+	}
+	if len(s.ConnsWithGroup(g2)) != 0 {
+		t.Fatal("should still have gotten none")
+	}
+	if len(s.connIdx) != 0 {
+		t.Fatal("should have an empty index")
+	}
+	if len(s.conns) != 0 {
+		t.Fatal("should not be holding any connections")
+	}
+}
+
+func TestAddConnWithGroups(t *testing.T) {
+	s := NewSwarm(nil)
+
+	g := "foo"
+	g2 := "bar"
+	g3 := "baz"
+
+	c, err := s.AddConn(new(fakeconn), g, g2)
+	if !c.InGroup(g) || !c.InGroup(g2) || c.InGroup(g3) {
+		t.Fatal("should be in the appropriate groups")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(s.ConnsWithGroup(g)) != 1 {
+		t.Fatal("should have gotten one")
+	}
+
+	if len(s.ConnsWithGroup(g2)) != 1 {
+		t.Fatal("should have gotten one")
+	}
+
+	if len(s.ConnsWithGroup(g3)) != 0 {
+		t.Fatal("should have gotten none")
+	}
+
+	c.Close()
+	if len(s.ConnsWithGroup(g)) != 0 {
+		t.Fatal("should have gotten none")
+	}
+
+	if len(s.ConnsWithGroup(g2)) != 0 {
+		t.Fatal("should have gotten none")
+	}
+
+	if len(s.ConnsWithGroup(g3)) != 0 {
+		t.Fatal("should still have gotten none")
+	}
+
+	if len(s.connIdx) != 0 {
+		t.Fatal("should have an empty index")
+	}
+	if len(s.conns) != 0 {
+		t.Fatal("should not be holding any connections")
+	}
+}

--- a/example/example.go
+++ b/example/example.go
@@ -108,7 +108,7 @@ func main() {
 	// Or, you can bind connections to ConnGroup ids. You can bind a conn to
 	// multiple groups. And, if conn wasn't in swarm, it calls swarm.AddConn.
 	// You can use any Go `KeyType` as a group A `KeyType` as in maps...)
-	swarm.AddConnToGroup(c2, 1)
+	c2.AddGroup(1)
 
 	// And then use that group to select a connection. Swarm will use any
 	// connection it finds in that group, using a SelectConn you can rebind:

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,0 +1,51 @@
+package peerstream
+
+import (
+	"errors"
+	"io"
+	"sync"
+
+	smux "github.com/libp2p/go-stream-muxer"
+)
+
+type fakeSmuxStream struct {
+	smux.Stream
+	conn      *fakeSmuxConn
+	closeLock sync.Mutex
+	closed    chan struct{}
+}
+
+func (fss *fakeSmuxStream) Close() error {
+	fss.closeLock.Lock()
+	defer fss.closeLock.Unlock()
+
+	select {
+	case <-fss.conn.closed:
+		return errors.New("already closed")
+	case <-fss.closed:
+		return errors.New("already closed")
+	default:
+	}
+	close(fss.closed)
+	return nil
+}
+
+func (fss *fakeSmuxStream) Read(b []byte) (int, error) {
+	select {
+	case <-fss.closed:
+	case <-fss.conn.closed:
+	}
+	return 0, io.EOF
+}
+
+func (fss *fakeSmuxStream) Write(b []byte) (int, error) {
+	select {
+	case <-fss.closed:
+	case <-fss.conn.closed:
+	}
+	return 0, errors.New("connection closed")
+}
+
+func (fss *fakeSmuxStream) Reset() error {
+	return fss.Close()
+}

--- a/swarm.go
+++ b/swarm.go
@@ -66,17 +66,17 @@ func NewSwarm(t smux.Transport) *Swarm {
 
 // String returns a string with various internal stats
 func (s *Swarm) String() string {
-	s.listenerLock.Lock()
+	s.listenerLock.RLock()
 	ls := len(s.listeners)
-	s.listenerLock.Unlock()
+	s.listenerLock.RUnlock()
 
-	s.connLock.Lock()
+	s.connLock.RLock()
 	cs := len(s.conns)
-	s.connLock.Unlock()
+	s.connLock.RUnlock()
 
-	s.streamLock.Lock()
+	s.streamLock.RLock()
 	ss := len(s.streams)
-	s.streamLock.Unlock()
+	s.streamLock.RUnlock()
 
 	str := "<peerstream.Swarm %d listeners %d conns %d streams>"
 	return fmt.Sprintf(str, ls, cs, ss)
@@ -86,23 +86,23 @@ func (s *Swarm) String() string {
 func (s *Swarm) Dump() string {
 	str := s.String() + "\n"
 
-	s.listenerLock.Lock()
+	s.listenerLock.RLock()
 	for l := range s.listeners {
 		str += fmt.Sprintf("\t%s %v\n", l, l.Groups())
 	}
-	s.listenerLock.Unlock()
+	s.listenerLock.RUnlock()
 
-	s.connLock.Lock()
+	s.connLock.RLock()
 	for c := range s.conns {
 		str += fmt.Sprintf("\t%s %v\n", c, c.Groups())
 	}
-	s.connLock.Unlock()
+	s.connLock.RUnlock()
 
-	s.streamLock.Lock()
+	s.streamLock.RLock()
 	for ss := range s.streams {
 		str += fmt.Sprintf("\t%s %v\n", ss, ss.Groups())
 	}
-	s.streamLock.Unlock()
+	s.streamLock.RUnlock()
 
 	return str
 }

--- a/swarm.go
+++ b/swarm.go
@@ -26,10 +26,9 @@ type Swarm struct {
 	streamLock sync.RWMutex
 
 	// active connections. generate new Streams
-	conns     map[*Conn]struct{}
-	connIdx   map[Group]map[*Conn]struct{}
-	connByNet map[tpt.Conn]*Conn
-	connLock  sync.RWMutex
+	conns    map[*Conn]struct{}
+	connIdx  map[Group]map[*Conn]struct{}
+	connLock sync.RWMutex
 
 	// active listeners. generate new Listeners
 	listeners    map[*Listener]struct{}
@@ -55,7 +54,6 @@ func NewSwarm(t smux.Transport) *Swarm {
 		transport:     t,
 		streams:       make(map[*Stream]struct{}),
 		conns:         make(map[*Conn]struct{}),
-		connByNet:     make(map[tpt.Conn]*Conn),
 		connIdx:       make(map[Group]map[*Conn]struct{}),
 		listeners:     make(map[*Listener]struct{}),
 		notifiees:     make(map[Notifiee]struct{}),
@@ -259,10 +257,11 @@ func (s *Swarm) AddListener(l tpt.Listener, groups ...Group) (*Listener, error) 
 // depends on the RateLimit option
 // func (s *Swarm) AddListenerWithRateLimit(net.Listner, RateLimit) // TODO
 
-// AddConn gives the Swarm ownership of tpt.Conn. The Swarm will open a
-// SPDY session and begin listening for Streams.
-// Returns the resulting Swarm-associated peerstream.Conn.
-// Idempotent: if the Connection has already been added, this is a no-op.
+// AddConn gives the Swarm ownership of tpt.Conn. The Swarm will negotiate an
+// appropriate multiplexer for the connection and and begin listening for
+// Streams. Returns the resulting Swarm-associated peerstream.Conn.
+//
+// Do not use the tpt.Conn once you've passed it to this method.
 func (s *Swarm) AddConn(tptConn tpt.Conn, groups ...Group) (*Conn, error) {
 	return s.addConn(tptConn, false, groups)
 }

--- a/swarm.go
+++ b/swarm.go
@@ -10,9 +10,6 @@ import (
 	smux "github.com/libp2p/go-stream-muxer"
 )
 
-// fd is a (file) descriptor, unix style
-type fd uint32
-
 // GarbageCollectTimeout governs the periodic connection closer.
 var GarbageCollectTimeout = 5 * time.Second
 

--- a/swarm.go
+++ b/swarm.go
@@ -204,8 +204,9 @@ func (s *Swarm) Conns() []*Conn {
 // ConnsWithGroup returns all the connections with a given Group
 func (s *Swarm) ConnsWithGroup(g Group) []*Conn {
 	s.connLock.RLock()
-	conns := make([]*Conn, 0, 1)
-	for c := range s.connIdx[g] {
+	cs := s.connIdx[g]
+	conns := make([]*Conn, 0, len(cs))
+	for c := range cs {
 		conns = append(conns, c)
 	}
 	s.connLock.RUnlock()

--- a/swarm.go
+++ b/swarm.go
@@ -26,9 +26,10 @@ type Swarm struct {
 	streamLock sync.RWMutex
 
 	// active connections. generate new Streams
-	conns    map[*Conn]struct{}
-	connIdx  map[Group]map[*Conn]struct{}
-	connLock sync.RWMutex
+	conns     map[*Conn]struct{}
+	connIdx   map[Group]map[*Conn]struct{}
+	connByNet map[tpt.Conn]*Conn
+	connLock  sync.RWMutex
 
 	// active listeners. generate new Listeners
 	listeners    map[*Listener]struct{}
@@ -54,6 +55,7 @@ func NewSwarm(t smux.Transport) *Swarm {
 		transport:     t,
 		streams:       make(map[*Stream]struct{}),
 		conns:         make(map[*Conn]struct{}),
+		connByNet:     make(map[tpt.Conn]*Conn),
 		connIdx:       make(map[Group]map[*Conn]struct{}),
 		listeners:     make(map[*Listener]struct{}),
 		notifiees:     make(map[Notifiee]struct{}),

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -158,3 +158,39 @@ func TestAddConnTwice(t *testing.T) {
 		t.Fatalf("initialized a single net conn twice: %v != %v", ca, cb)
 	}
 }
+
+func TestConnIdx(t *testing.T) {
+	s := NewSwarm(nil)
+	c, err := s.AddConn(new(fakeconn))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	g := "foo"
+	g2 := "foo"
+
+	if len(s.ConnsWithGroup(g)) != 0 {
+		t.Fatal("should have gotten none")
+	}
+
+	c.AddGroup(g)
+	if len(s.ConnsWithGroup(g)) != 1 {
+		t.Fatal("should have only gotten one")
+	}
+
+	c.Close()
+	if len(s.ConnsWithGroup(g)) != 0 {
+		t.Fatal("should have gotten none")
+	}
+
+	c.AddGroup(g2)
+	if len(s.ConnsWithGroup(g)) != 0 {
+		t.Fatal("should still have gotten none")
+	}
+	if len(s.connIdx) != 0 {
+		t.Fatal("should have an empty index")
+	}
+	if len(s.conns) != 0 {
+		t.Fatal("should not be holding any connections")
+	}
+}

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -7,17 +7,8 @@ import (
 	"testing"
 	"time"
 
-	tpt "github.com/libp2p/go-libp2p-transport"
 	smux "github.com/libp2p/go-stream-muxer"
 )
-
-type fakeconn struct {
-	tpt.Conn
-}
-
-func (f *fakeconn) Close() error {
-	return nil
-}
 
 type fakeTransport struct {
 	f func(c net.Conn, isServer bool) (smux.Conn, error)
@@ -77,187 +68,12 @@ func TestNotificationOrdering(t *testing.T) {
 				}
 				c.Close()
 			}
+
 		}()
 	}
 
 	wg.Wait()
 	if notifiee.failed {
 		t.Fatal("we've got problems")
-	}
-}
-
-type fakeSmuxConn struct {
-	smux.Conn
-	closed bool
-}
-
-func (fsc fakeSmuxConn) IsClosed() bool {
-	return fsc.closed
-}
-
-func (fsc fakeSmuxConn) Close() error {
-	return nil
-}
-
-func TestConnsWithGroup(t *testing.T) {
-	s := NewSwarm(nil)
-	a := newConn(nil, &fakeSmuxConn{}, s)
-	b := newConn(nil, &fakeSmuxConn{closed: true}, s)
-	c := newConn(nil, &fakeSmuxConn{closed: true}, s)
-	g := "foo"
-
-	s.conns[a] = struct{}{}
-	s.conns[b] = struct{}{}
-	s.conns[c] = struct{}{}
-
-	a.AddGroup(g)
-	b.AddGroup(g)
-	c.AddGroup(g)
-
-	conns := s.ConnsWithGroup(g)
-	if len(conns) != 1 {
-		t.Fatal("should have only gotten one")
-	}
-
-	if !b.closing {
-		t.Fatal("b should at least be closing")
-	}
-
-	if !c.closing {
-		t.Fatal("c should at least be closing")
-	}
-}
-
-func TestAddConnTwice(t *testing.T) {
-	ready := new(sync.WaitGroup)
-	pause := make(chan struct{})
-	conns := make(chan *Conn)
-	s := NewSwarm(fakeTransport{func(c net.Conn, isServer bool) (smux.Conn, error) {
-		ready.Done()
-		<-pause
-		return nil, nil
-	}})
-	c := new(fakeconn)
-	for i := 0; i < 2; i++ {
-		ready.Add(1)
-		go func() {
-			pc, err := s.AddConn(c)
-			if err != nil {
-				t.Error(err)
-			}
-			conns <- pc
-		}()
-	}
-	ready.Wait()
-	close(pause)
-
-	ca := <-conns
-	cb := <-conns
-
-	if ca != cb {
-		t.Fatalf("initialized a single net conn twice: %v != %v", ca, cb)
-	}
-	ca.Close()
-	if len(s.connByNet) != 0 || len(s.conns) != 0 {
-		t.Fatal("leaked connections")
-	}
-}
-
-func TestConnIdx(t *testing.T) {
-	s := NewSwarm(nil)
-	c, err := s.AddConn(new(fakeconn))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	g := "foo"
-	g2 := "bar"
-
-	if len(s.ConnsWithGroup(g)) != 0 {
-		t.Fatal("should have gotten none")
-	}
-
-	c.AddGroup(g)
-	if !c.InGroup(g) {
-		t.Fatal("should be in the appropriate group")
-	}
-	if len(s.ConnsWithGroup(g)) != 1 {
-		t.Fatal("should have only gotten one")
-	}
-
-	c.Close()
-	if !c.InGroup(g) {
-		t.Fatal("should still be in the appropriate group")
-	}
-	if len(s.ConnsWithGroup(g)) != 0 {
-		t.Fatal("should have gotten none")
-	}
-
-	c.AddGroup(g2)
-	if !c.InGroup(g2) {
-		t.Fatal("should now be in group 2")
-	}
-	if c.InGroup("bla") {
-		t.Fatal("should not be in arbitrary groups")
-	}
-	if len(s.ConnsWithGroup(g)) != 0 {
-		t.Fatal("should still have gotten none")
-	}
-	if len(s.ConnsWithGroup(g2)) != 0 {
-		t.Fatal("should still have gotten none")
-	}
-	if len(s.connIdx) != 0 {
-		t.Fatal("should have an empty index")
-	}
-	if len(s.conns) != 0 {
-		t.Fatal("should not be holding any connections")
-	}
-}
-
-func TestAddConnWithGroups(t *testing.T) {
-	s := NewSwarm(nil)
-
-	g := "foo"
-	g2 := "bar"
-	g3 := "baz"
-
-	c, err := s.AddConn(new(fakeconn), g, g2)
-	if !c.InGroup(g) || !c.InGroup(g2) || c.InGroup(g3) {
-		t.Fatal("should be in the appropriate groups")
-	}
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(s.ConnsWithGroup(g)) != 1 {
-		t.Fatal("should have gotten one")
-	}
-
-	if len(s.ConnsWithGroup(g2)) != 1 {
-		t.Fatal("should have gotten one")
-	}
-
-	if len(s.ConnsWithGroup(g3)) != 0 {
-		t.Fatal("should have gotten none")
-	}
-
-	c.Close()
-	if len(s.ConnsWithGroup(g)) != 0 {
-		t.Fatal("should have gotten none")
-	}
-
-	if len(s.ConnsWithGroup(g2)) != 0 {
-		t.Fatal("should have gotten none")
-	}
-
-	if len(s.ConnsWithGroup(g3)) != 0 {
-		t.Fatal("should still have gotten none")
-	}
-
-	if len(s.connIdx) != 0 {
-		t.Fatal("should have an empty index")
-	}
-	if len(s.conns) != 0 {
-		t.Fatal("should not be holding any connections")
 	}
 }

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -157,6 +157,10 @@ func TestAddConnTwice(t *testing.T) {
 	if ca != cb {
 		t.Fatalf("initialized a single net conn twice: %v != %v", ca, cb)
 	}
+	ca.Close()
+	if len(s.connByNet) != 0 || len(s.conns) != 0 {
+		t.Fatal("leaked connections")
+	}
 }
 
 func TestConnIdx(t *testing.T) {

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -178,8 +178,67 @@ func TestConnIdx(t *testing.T) {
 	}
 
 	c.AddGroup(g)
+	if !c.InGroup(g) {
+		t.Fatal("should be in the appropriate group")
+	}
 	if len(s.ConnsWithGroup(g)) != 1 {
 		t.Fatal("should have only gotten one")
+	}
+
+	c.Close()
+	if !c.InGroup(g) {
+		t.Fatal("should still be in the appropriate group")
+	}
+	if len(s.ConnsWithGroup(g)) != 0 {
+		t.Fatal("should have gotten none")
+	}
+
+	c.AddGroup(g2)
+	if !c.InGroup(g2) {
+		t.Fatal("should now be in group 2")
+	}
+	if c.InGroup("bla") {
+		t.Fatal("should not be in arbitrary groups")
+	}
+	if len(s.ConnsWithGroup(g)) != 0 {
+		t.Fatal("should still have gotten none")
+	}
+	if len(s.ConnsWithGroup(g2)) != 0 {
+		t.Fatal("should still have gotten none")
+	}
+	if len(s.connIdx) != 0 {
+		t.Fatal("should have an empty index")
+	}
+	if len(s.conns) != 0 {
+		t.Fatal("should not be holding any connections")
+	}
+}
+
+func TestAddConnWithGroups(t *testing.T) {
+	s := NewSwarm(nil)
+
+	g := "foo"
+	g2 := "bar"
+	g3 := "baz"
+
+	c, err := s.AddConn(new(fakeconn), g, g2)
+	if !c.InGroup(g) || !c.InGroup(g2) || c.InGroup(g3) {
+		t.Fatal("should be in the appropriate groups")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(s.ConnsWithGroup(g)) != 1 {
+		t.Fatal("should have gotten one")
+	}
+
+	if len(s.ConnsWithGroup(g2)) != 1 {
+		t.Fatal("should have gotten one")
+	}
+
+	if len(s.ConnsWithGroup(g3)) != 0 {
+		t.Fatal("should have gotten none")
 	}
 
 	c.Close()
@@ -187,10 +246,14 @@ func TestConnIdx(t *testing.T) {
 		t.Fatal("should have gotten none")
 	}
 
-	c.AddGroup(g2)
-	if len(s.ConnsWithGroup(g)) != 0 {
+	if len(s.ConnsWithGroup(g2)) != 0 {
+		t.Fatal("should have gotten none")
+	}
+
+	if len(s.ConnsWithGroup(g3)) != 0 {
 		t.Fatal("should still have gotten none")
 	}
+
 	if len(s.connIdx) != 0 {
 		t.Fatal("should have an empty index")
 	}

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -171,7 +171,7 @@ func TestConnIdx(t *testing.T) {
 	}
 
 	g := "foo"
-	g2 := "foo"
+	g2 := "bar"
 
 	if len(s.ConnsWithGroup(g)) != 0 {
 		t.Fatal("should have gotten none")

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -96,13 +96,14 @@ func TestConnsWithGroup(t *testing.T) {
 	b := newConn(nil, &fakeSmuxConn{closed: true}, s)
 	c := newConn(nil, &fakeSmuxConn{closed: true}, s)
 	g := "foo"
-	a.AddGroup(g)
-	b.AddGroup(g)
-	c.AddGroup(g)
 
 	s.conns[a] = struct{}{}
 	s.conns[b] = struct{}{}
 	s.conns[c] = struct{}{}
+
+	a.AddGroup(g)
+	b.AddGroup(g)
+	c.AddGroup(g)
 
 	conns := s.ConnsWithGroup(g)
 	if len(conns) != 1 {

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -114,4 +114,18 @@ func TestBasicSwarm(t *testing.T) {
 	if streams[0] != st || streamsInGroup[0] != st {
 		t.Fatal("expected our stream")
 	}
+
+	// Make sure these don't crash or deadlock.
+	s.String()
+	s.String()
+	s.Dump()
+	s.Dump()
+
+	if s.String() == "" {
+		t.Fatal("got no 'String' from swarm")
+	}
+
+	if s.Dump() == "" {
+		t.Fatal("got no 'Dump' from swarm")
+	}
 }


### PR DESCRIPTION
After this patch, go-peerstream no longer shows up as a CPU hog.

I would have liked to have removed groups entirely but peerstream doesn't understand the concept of peer IDs so we need *some* form of general-purpose grouping/tagging mechanism. However, we can, and probably should, get rid of groups on streams and listeners to reduce complexity.