### PR TITLE
close connections after failing to multiplex them

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -263,6 +263,7 @@ func (s *Swarm) setupConn(netConn tpt.Conn, isServer bool, initialGroups []Group
 		// create a new stream muxer connection
 		c, err := s.transport.NewConn(netConn, isServer)
 		if err != nil {
+			netConn.Close()
 			return nil, err
 		}
 


### PR DESCRIPTION
Otherwise, we leak them.

fixes libp2p/go-ws-transport#21