### PR TITLE
check if we *have* a stream muxer

### DIFF
--- a/swarm.go
+++ b/swarm.go
@@ -325,6 +325,10 @@ func (s *Swarm) NewStreamWithConn(conn *Conn) (*Stream, error) {
 		return nil, errors.New("connection not associated with swarm")
 	}
 
+	if conn.smuxConn == nil {
+		return nil, errors.New("connection does not support multiplexing streams")
+	}
+
 	if conn.smuxConn.IsClosed() {
 		go conn.Close()
 		return nil, errors.New("conn is closed")

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -78,6 +78,31 @@ func TestNotificationOrdering(t *testing.T) {
 	}
 }
 
+func TestNewStreamNoMuxer(t *testing.T) {
+	s := NewSwarm(nil)
+	c, err := s.AddConn(new(fakeconn), "foo", "bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !c.InGroup("foo") || !c.InGroup("bar") || c.InGroup("baz") {
+		t.Fatal("conn should be in groups bar and baz")
+	}
+	conns := s.Conns()
+	connsInGroup := s.ConnsWithGroup("bar")
+	if len(conns) != 1 || len(connsInGroup) != 1 {
+		t.Fatal("expected one conn")
+	}
+	if conns[0] != c || connsInGroup[0] != c {
+		t.Fatal("expected our conn")
+	}
+
+	_, err = c.NewStream()
+	if err == nil {
+		t.Fatal("new stream should have failed")
+	}
+}
+
 func TestBasicSwarm(t *testing.T) {
 	s := NewSwarm(fakeTransport{func(c net.Conn, isServer bool) (smux.Conn, error) {
 		return newFakeSmuxConn(), nil


### PR DESCRIPTION
(in the near future, we'll require one but we don't for now so let's stop
crashing on users)